### PR TITLE
Allow to tag visualdiffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,14 +333,17 @@ export const config = defineVisualDiffConfig({
         {
           name: "Articles",
           path: "/en/articles",
+          tags: ["@articles"],
         },
         {
           name: "Recipes",
           path: "/en/recipes",
+          tags: ["@recipes"],
         },
         {
           name: "Alternate Recipe View",
           path: "/en/recipes-alt",
+          tags: ["@recipes"],
           skip: {
             reason: "The recipes are listed in random order",
             willBeFixedIn: "https://drupal.org/node/12345",

--- a/src/testcase/visualdiff.ts
+++ b/src/testcase/visualdiff.ts
@@ -99,7 +99,9 @@ export class VisualDiffTestCases {
             testFunction = overriddenTestFunction(testCase, group);
           }
 
-          test(`${testCase.name}: ${testCase.path}`, testFunction);
+          test(`${testCase.name}: ${testCase.path}`, {
+            tag: testCase.tags
+          }, testFunction);
         }));
       });
     });
@@ -147,6 +149,7 @@ export type BaseVisualDiff = {
   representativeUrl?: string,
   // Allow skipping of this test.
   skip?: SkipTest,
+  tags?: string[],
 }
 
 /**


### PR DESCRIPTION
This makes easier to regenerate when you have lots of visualdiffs and you know which changes are needed.
This is useful e.g. if you tag them with the view modes being used in a url.